### PR TITLE
Make configuration root configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,37 @@ If you use sbt, add this dependency to your `build.sbt` file:
 libraryDependencies += "org.gnieh" % "logback.config" % "0.1.0"
 ```
 
+Configuration root
+------------------
+
+By default the logback configuration keys are all under the top-level `logback` key. You can override this by changing the value of the `logback-root` key.
+For instance, let's say you have two different logging configurations, one for testing and one for production. In your `reference.conf` file you can have:
+
+```scala
+logback-root = production.logback
+
+production {
+  logback = ${logback} {
+    // logging configruation, see below
+  }
+}
+```
+
+In your test configuration file you may then have:
+
+```scala
+logback-root = test.logback
+
+test {
+  logback = ${logback} {
+    // logging configruation, see below
+  }
+}
+```
+
+Inheriting from the default `logback` configuration object brings a valid empty configuration, so that only required keys must be defined.
+It is not necessary though, if your configuration defines all the required keys (`appenders`, `loggers`, and `root`, see below).
+
 Format
 ------
 
@@ -104,10 +135,10 @@ Encoder configuration looks like this:
 
   // optional
   level = DEBUG // or any other level as described at https://logback.qos.ch/manual/architecture.html#effectiveLevel
-  
+
   // optional
   additivity = true // or any other boolean value (see conversions below) as described at https://logback.qos.ch/manual/architecture.html#additivity
-  
+
   // optional
   appenders = [ "appender-name", ... ]
 }
@@ -130,6 +161,6 @@ integer         | `int`
 floating point  | `double`
 string          | `java.lang.String`
 boolean         | `boolean`
-null            | `null` 
+null            | `null`
 array           | `java.util.List`
 object          | `java.util.Map<java.lang.String,java.lang.Object>`

--- a/src/main/java/org/gnieh/logback/config/ConfigConfigurator.java
+++ b/src/main/java/org/gnieh/logback/config/ConfigConfigurator.java
@@ -42,7 +42,7 @@ import ch.qos.logback.core.spi.LifeCycle;
 /**
  * A configurator using Typesafe's config library to lookup and load logger
  * configuration.
- * 
+ *
  * @author Lucas Satabin
  *
  */
@@ -55,10 +55,13 @@ public class ConfigConfigurator extends ContextAwareBase implements Configurator
 
 		BeanDescriptionCache beanCache = new BeanDescriptionCache(loggerContext);
 
+		final Config config = ConfigFactory.load();
+		// get the logback configuration root
+		final String logbackConfigRoot = config.getString("logback-root");
 		// load the configuration per config loading rules
-		final Config config = ConfigFactory.load().getConfig("logback");
+		final Config logbackConfig = config.getConfig(logbackConfigRoot);
 
-		final Config appenderConfigs = config.getConfig("appenders");
+		final Config appenderConfigs = logbackConfig.getConfig("appenders");
 		final Map<String, Appender<ILoggingEvent>> appenders = new HashMap<>();
 		for (Entry<String, ConfigValue> entry : appenderConfigs.root().entrySet()) {
 			if (entry.getValue() instanceof ConfigObject) {
@@ -73,15 +76,15 @@ public class ConfigConfigurator extends ContextAwareBase implements Configurator
 			}
 		}
 
-		if (config.hasPath("root")) {
-			if (config.getValue("root") instanceof ConfigObject) {
-				configureLogger(loggerContext, appenders, Logger.ROOT_LOGGER_NAME, config.getConfig("root"), true);
+		if (logbackConfig.hasPath("root")) {
+			if (logbackConfig.getValue("root") instanceof ConfigObject) {
+				configureLogger(loggerContext, appenders, Logger.ROOT_LOGGER_NAME, logbackConfig.getConfig("root"), true);
 			} else {
 				addWarn("Invalid ROOT logger configuration. Ignoring it.");
 			}
 		}
 
-		Config loggerConfigs = config.getConfig("loggers");
+		Config loggerConfigs = logbackConfig.getConfig("loggers");
 		for (Entry<String, ConfigValue> entry : loggerConfigs.root().entrySet()) {
 			if (entry.getValue() instanceof ConfigObject) {
 				configureLogger(loggerContext, appenders, entry.getKey(),
@@ -119,7 +122,7 @@ public class ConfigConfigurator extends ContextAwareBase implements Configurator
 
 	/**
 	 * Configure an object of a given class.
-	 * 
+	 *
 	 * @param loggerContext
 	 *            the context to assign to this object if it is
 	 *            {@link ContextAwareBase}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,3 +1,5 @@
+logback-root = logback
+
 logback {
 
   loggers {}

--- a/src/test/resources/bean.conf
+++ b/src/test/resources/bean.conf
@@ -1,29 +1,29 @@
 {
-	
+
 	int-property: 12
-	
+
 	long-property: 120000000000000000
-	
+
 	float-property: 1.2
-	
+
 	double-property: 1.1
-	
+
 	stringProperty: "This is a test"
-	
+
 	duration: 12 days
-	
+
 	size: 2 GiB
-	
+
 	sub-config {
-		
+
 		k1: 2
-		
+
 		k2: test
-		
+
 	}
-	
+
 	enum-property: VALUE1
-	
+
 	ints = [1, 2, 3, 4, 5]
-	
+
 }

--- a/src/test/resources/multipleLoggers.conf
+++ b/src/test/resources/multipleLoggers.conf
@@ -1,4 +1,6 @@
-logback {
+logback-root = test.logback
+
+test.logback {
   appenders {
     file = {
       class = "ch.qos.logback.core.FileAppender"
@@ -10,7 +12,7 @@ logback {
         pattern = "%date %level %logger %thread %msg%n"
       }
     }
-    
+
     console = {
       class = "ch.qos.logback.core.ConsoleAppender"
       encoder {
@@ -20,18 +22,18 @@ logback {
       }
     }
   }
-  
+
   loggers {
     "org.gnieh" {
       level = DEBUG
       appenders = [ console, file ]
     }
-    
+
     "org.gnieh.logback" {
       level = TRACE
     }
   }
-  
+
   root {
     level = INFO
     appenders = [ console ]

--- a/src/test/resources/rollingFileAppender.conf
+++ b/src/test/resources/rollingFileAppender.conf
@@ -1,4 +1,6 @@
-logback {
+logback-root = test.logback
+
+test.logback = ${logback} {
   appenders {
     rolling = {
       class = "ch.qos.logback.core.rolling.RollingFileAppender"
@@ -7,21 +9,21 @@ logback {
         charset = "UTF-8"
         pattern = "%date %level %logger %thread %msg%n"
       }
-      
+
       file = "logs/test.log"
-      
+
       rolling-policy = {
         class = "ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy"
-        
+
         file-name-pattern = "logs/test%d{yyyy-MM-dd}.%i.log"
-        
+
         max-file-size = "5MB"
-        
+
         max-history = 30
       }
     }
   }
-  
+
   root {
     level = INFO
     appenders = [ rolling ]


### PR DESCRIPTION
It may be the case that several logging configurations exist while being
mutually exclusive (e.g. test vs prod). Making the configuration root
configurable makes it possible to switch between these configurations in
different environments quite easily.