### PR TITLE
Add support for logback string substitutions

### DIFF
--- a/src/main/java/org/gnieh/logback/config/ConfigConfigurator.java
+++ b/src/main/java/org/gnieh/logback/config/ConfigConfigurator.java
@@ -151,7 +151,7 @@ public class ConfigConfigurator extends ContextAwareBase implements Configurator
 
 		// file property (if any) must be set before any other property for appenders
 		if (config.hasPath("file")) {
-			propertySetter.setProperty("file", config);
+			propertySetter.setProperty("file", config, context);
 		}
 
 		for (Entry<String, ConfigValue> entry : config.withoutPath("class").withoutPath("file").root().entrySet()) {
@@ -167,11 +167,11 @@ public class ConfigConfigurator extends ContextAwareBase implements Configurator
 					if (children != null)
 						children.add(child);
 				} else {
-					propertySetter.setProperty(entry.getKey(), config);
+					propertySetter.setProperty(entry.getKey(), config, context);
 				}
 				break;
 			default:
-				propertySetter.setProperty(entry.getKey(), config);
+				propertySetter.setProperty(entry.getKey(), config, context);
 				break;
 			}
 		}

--- a/src/test/java/org/gnieh/logback/config/ConfigPropertySetterTest.java
+++ b/src/test/java/org/gnieh/logback/config/ConfigPropertySetterTest.java
@@ -29,7 +29,7 @@ public class ConfigPropertySetterTest {
 
 		Assert.assertEquals(0, bean.getIntProperty());
 
-		propertySetter.setProperty("int-property", config);
+		propertySetter.setProperty("int-property", config, null);
 
 		Assert.assertEquals(12, bean.getIntProperty());
 
@@ -46,7 +46,7 @@ public class ConfigPropertySetterTest {
 
 		Assert.assertEquals(0l, bean.getLongProperty());
 
-		propertySetter.setProperty("long-property", config);
+		propertySetter.setProperty("long-property", config, null);
 
 		Assert.assertEquals(120000000000000000l, bean.getLongProperty());
 
@@ -63,7 +63,7 @@ public class ConfigPropertySetterTest {
 
 		Assert.assertEquals(0.0f, bean.getFloatProperty(), 0.0f);
 
-		propertySetter.setProperty("float-property", config);
+		propertySetter.setProperty("float-property", config, null);
 
 		Assert.assertEquals(1.2f, bean.getFloatProperty(), 0.0f);
 
@@ -80,7 +80,7 @@ public class ConfigPropertySetterTest {
 
 		Assert.assertEquals(0.0d, bean.getDoubleProperty(), 0.0d);
 
-		propertySetter.setProperty("double-property", config);
+		propertySetter.setProperty("double-property", config, null);
 
 		Assert.assertEquals(1.1d, bean.getDoubleProperty(), 0.0d);
 
@@ -97,7 +97,7 @@ public class ConfigPropertySetterTest {
 
 		Assert.assertEquals(null, bean.getStringProperty());
 
-		propertySetter.setProperty("stringProperty", config);
+		propertySetter.setProperty("stringProperty", config, null);
 
 		Assert.assertEquals("This is a test", bean.getStringProperty());
 
@@ -114,7 +114,7 @@ public class ConfigPropertySetterTest {
 
 		Assert.assertEquals(null, bean.getDuration());
 
-		propertySetter.setProperty("duration", config);
+		propertySetter.setProperty("duration", config, null);
 
 		Assert.assertEquals(Duration.ofDays(12), bean.getDuration());
 
@@ -131,7 +131,7 @@ public class ConfigPropertySetterTest {
 
 		Assert.assertEquals(null, bean.getSize());
 
-		propertySetter.setProperty("size", config);
+		propertySetter.setProperty("size", config, null);
 
 		Assert.assertEquals(ConfigMemorySize.ofBytes(2048l * 1024l * 1024l), bean.getSize());
 
@@ -148,7 +148,7 @@ public class ConfigPropertySetterTest {
 
 		Assert.assertEquals(null, bean.getSubConfig());
 
-		propertySetter.setProperty("sub-config", config);
+		propertySetter.setProperty("sub-config", config, null);
 
 		Assert.assertEquals(config.getConfig("sub-config"), bean.getSubConfig());
 
@@ -165,7 +165,7 @@ public class ConfigPropertySetterTest {
 
 		Assert.assertEquals(null, bean.getEnumProperty());
 
-		propertySetter.setProperty("enum-property", config);
+		propertySetter.setProperty("enum-property", config, null);
 
 		Assert.assertEquals(TestEnum.VALUE1, bean.getEnumProperty());
 
@@ -182,7 +182,7 @@ public class ConfigPropertySetterTest {
 
 		Assert.assertEquals(Collections.emptyList(), bean.getInts());
 
-		propertySetter.setProperty("ints", config);
+		propertySetter.setProperty("ints", config, null);
 
 		List<Integer> l = new ArrayList<>();
 		l.add(1);


### PR DESCRIPTION
To make it easier to substitute variables with default values inlined in
strings, add support for logback string substitution inside string
literals.
One can of course use config string substitution but in some cases, it
is handier to use the logback ones.