### PR TITLE
Reload on file change

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The general configuration format is as follows:
 
 ```scala
 logback {
-  scanPeriod = 30 seconds
+  scan-period = 30 seconds
 
   appenders {
     appender-name {

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The configurator first attempts to load the Typesafe configuration through the J
 for a service-provider for the `org.gnieh.logback.config.ConfigLoader` interface, and calls the first one that it find.
 If none are found the Typesafe configuration is loaded by a call to ConfigFactory.load().
 
-If the configuration value `scanPeriod` is assigned a duration value then all regular files (those directly contained in
+If the configuration value `scan-period` is assigned a duration value then all regular files (those directly contained in
 the file system) encountered in the Typesafe configuration will be checked for changes at that interval, and the
 configuration will be reloaded if any have been modified.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ The configurator first attempts to load the Typesafe configuration through the J
 for a service-provider for the `org.gnieh.logback.config.ConfigLoader` interface, and calls the first one that it find.
 If none are found the Typesafe configuration is loaded by a call to ConfigFactory.load().
 
+If the configuration value `scanPeriod` is assigned a duration value then all regular files (those directly contained in
+the file system) encountered in the Typesafe configuration will be checked for changes at that interval, and the
+configuration will be reloaded if any have been modified.
+
 Configuration root
 ------------------
 
@@ -68,6 +72,7 @@ The general configuration format is as follows:
 
 ```scala
 logback {
+  scanPeriod = 30 seconds
 
   appenders {
     appender-name {

--- a/src/main/java/org/gnieh/logback/config/ConfigConfigurator.java
+++ b/src/main/java/org/gnieh/logback/config/ConfigConfigurator.java
@@ -351,8 +351,8 @@ public class ConfigConfigurator extends ContextAwareBase implements Configurator
      * @param config        the logback TS-config
      */
     private void createChangeTask(LoggerContext loggerContext, Config config) {
-        if (config.hasPath("scanPeriod") && !config.getIsNull("scanPeriod")) {
-            long delay = config.getDuration("scanPeriod", TimeUnit.MILLISECONDS);
+        if (config.hasPath("scan-period") && !config.getIsNull("scan-eriod")) {
+            long delay = config.getDuration("scan-period", TimeUnit.MILLISECONDS);
             if (delay > 0) {
                 Runnable rocTask = () -> {
                     ConfigurationWatchList configurationWatchList =

--- a/src/main/java/org/gnieh/logback/config/ConfigConfigurator.java
+++ b/src/main/java/org/gnieh/logback/config/ConfigConfigurator.java
@@ -351,7 +351,7 @@ public class ConfigConfigurator extends ContextAwareBase implements Configurator
      * @param config        the logback TS-config
      */
     private void createChangeTask(LoggerContext loggerContext, Config config) {
-        if (config.hasPath("scan-period") && !config.getIsNull("scan-eriod")) {
+        if (config.hasPath("scan-period") && !config.getIsNull("scan-period")) {
             long delay = config.getDuration("scan-period", TimeUnit.MILLISECONDS);
             if (delay > 0) {
                 Runnable rocTask = () -> {


### PR DESCRIPTION
Part 2 - the file watcher. README included this time.

I also switched to a consistent use of loggerContext instead of context to avoid the cast, since we're passing it around everywhere anyway.