### PR TITLE
Support loading appenders that reference other appenders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ cache:
 script: sbt test
 
 jdk:
-  - oraclejdk8
+  - openjdk8

--- a/src/main/java/org/gnieh/logback/config/ConfigAppendersCache.java
+++ b/src/main/java/org/gnieh/logback/config/ConfigAppendersCache.java
@@ -1,0 +1,63 @@
+package org.gnieh.logback.config;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A lazy cache that supports appender references.
+ * If appender X references another appender Y - then the cache will load Y and set it as one of the properties of X.
+ *
+ * @author NiceBKB
+ */
+public class ConfigAppendersCache {
+	/**
+	 * The map of appender names to loaded appender objects
+	 */
+	private final Map<String, Appender<ILoggingEvent>> cache = new HashMap<>();
+	/**
+	 * Function that loads the appender from the appender name
+	 */
+	private AppenderLoader loader;
+
+	/**
+	 * Assigns the loading function.
+	 *
+	 * @param loader the function to be used to load the appender by name
+	 */
+	public void setLoader(AppenderLoader loader) {
+		this.loader = loader;
+	}
+
+	/**
+	 * Provides the existing appender or loads the new one by appender name.
+	 *
+	 * @param name the name of the appender to load
+	 * @return the loaded appender
+	 */
+	public Appender<ILoggingEvent> getAppender(String name) throws ReflectiveOperationException {
+		if (cache.containsKey(name)) {
+			return cache.get(name);
+		} else {
+			Appender<ILoggingEvent> appender = loader.load(name);
+			cache.put(name, appender);
+			return appender;
+		}
+	}
+
+	/**
+	 * Wraps the function for loading appenders by name.
+	 */
+	interface AppenderLoader {
+		/**
+		 * Loads the appender by name.
+		 *
+		 * @param name the name of the appender to load
+		 * @return the loaded appender
+		 * @throws ReflectiveOperationException when configuring appender fails
+		 */
+		Appender<ILoggingEvent> load(String name) throws ReflectiveOperationException;
+	}
+}

--- a/src/test/java/org/gnieh/logback/config/ConfigPropertySetterTest.java
+++ b/src/test/java/org/gnieh/logback/config/ConfigPropertySetterTest.java
@@ -1,10 +1,12 @@
 package org.gnieh.logback.config;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.FileAppender;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,7 +31,7 @@ public class ConfigPropertySetterTest {
 
 		Assert.assertEquals(0, bean.getIntProperty());
 
-		propertySetter.setProperty("int-property", config, null);
+		propertySetter.setProperty("int-property", config, null, null);
 
 		Assert.assertEquals(12, bean.getIntProperty());
 
@@ -46,7 +48,7 @@ public class ConfigPropertySetterTest {
 
 		Assert.assertEquals(0l, bean.getLongProperty());
 
-		propertySetter.setProperty("long-property", config, null);
+		propertySetter.setProperty("long-property", config, null, null);
 
 		Assert.assertEquals(120000000000000000l, bean.getLongProperty());
 
@@ -63,7 +65,7 @@ public class ConfigPropertySetterTest {
 
 		Assert.assertEquals(0.0f, bean.getFloatProperty(), 0.0f);
 
-		propertySetter.setProperty("float-property", config, null);
+		propertySetter.setProperty("float-property", config, null, null);
 
 		Assert.assertEquals(1.2f, bean.getFloatProperty(), 0.0f);
 
@@ -80,7 +82,7 @@ public class ConfigPropertySetterTest {
 
 		Assert.assertEquals(0.0d, bean.getDoubleProperty(), 0.0d);
 
-		propertySetter.setProperty("double-property", config, null);
+		propertySetter.setProperty("double-property", config, null, null);
 
 		Assert.assertEquals(1.1d, bean.getDoubleProperty(), 0.0d);
 
@@ -97,7 +99,7 @@ public class ConfigPropertySetterTest {
 
 		Assert.assertEquals(null, bean.getStringProperty());
 
-		propertySetter.setProperty("stringProperty", config, null);
+		propertySetter.setProperty("stringProperty", config, null, null);
 
 		Assert.assertEquals("This is a test", bean.getStringProperty());
 
@@ -114,7 +116,7 @@ public class ConfigPropertySetterTest {
 
 		Assert.assertEquals(null, bean.getDuration());
 
-		propertySetter.setProperty("duration", config, null);
+		propertySetter.setProperty("duration", config, null, null);
 
 		Assert.assertEquals(Duration.ofDays(12), bean.getDuration());
 
@@ -131,7 +133,7 @@ public class ConfigPropertySetterTest {
 
 		Assert.assertEquals(null, bean.getSize());
 
-		propertySetter.setProperty("size", config, null);
+		propertySetter.setProperty("size", config, null, null);
 
 		Assert.assertEquals(ConfigMemorySize.ofBytes(2048l * 1024l * 1024l), bean.getSize());
 
@@ -148,7 +150,7 @@ public class ConfigPropertySetterTest {
 
 		Assert.assertEquals(null, bean.getSubConfig());
 
-		propertySetter.setProperty("sub-config", config, null);
+		propertySetter.setProperty("sub-config", config, null, null);
 
 		Assert.assertEquals(config.getConfig("sub-config"), bean.getSubConfig());
 
@@ -165,7 +167,7 @@ public class ConfigPropertySetterTest {
 
 		Assert.assertEquals(null, bean.getEnumProperty());
 
-		propertySetter.setProperty("enum-property", config, null);
+		propertySetter.setProperty("enum-property", config, null, null);
 
 		Assert.assertEquals(TestEnum.VALUE1, bean.getEnumProperty());
 
@@ -182,7 +184,7 @@ public class ConfigPropertySetterTest {
 
 		Assert.assertEquals(Collections.emptyList(), bean.getInts());
 
-		propertySetter.setProperty("ints", config, null);
+		propertySetter.setProperty("ints", config, null, null);
 
 		List<Integer> l = new ArrayList<>();
 		l.add(1);
@@ -191,6 +193,35 @@ public class ConfigPropertySetterTest {
 		l.add(4);
 		l.add(5);
 		Assert.assertEquals(l, bean.getInts());
+
+	}
+
+	@Test
+	public void testAppenderListProperty() {
+
+		TestBean bean = new TestBean();
+
+		ConfigPropertySetter propertySetter = new ConfigPropertySetter(beanCache, bean);
+
+		Config config = ConfigFactory.load("bean");
+
+		Assert.assertEquals(Collections.emptyList(), bean.getAppenders());
+
+		Map<String, Appender<ILoggingEvent>> otherAppenders = new HashMap<>();
+		Appender<ILoggingEvent> testAppender1 = new FileAppender<>();
+		Appender<ILoggingEvent> testAppender2 = new ConsoleAppender<>();
+		otherAppenders.put("test-appender-1", testAppender1);
+		otherAppenders.put("test-appender-2", testAppender2);
+
+		ConfigAppendersCache appendersCache = new ConfigAppendersCache();
+		appendersCache.setLoader(otherAppenders::get);
+
+		propertySetter.setProperty("appenders", config, null, appendersCache);
+
+		List<Appender<ILoggingEvent>> l = new ArrayList<>();
+		l.add(testAppender1);
+		l.add(testAppender2);
+		Assert.assertEquals(l, bean.getAppenders());
 
 	}
 

--- a/src/test/java/org/gnieh/logback/config/TestBean.java
+++ b/src/test/java/org/gnieh/logback/config/TestBean.java
@@ -4,6 +4,8 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigMemorySize;
 
@@ -28,6 +30,8 @@ public class TestBean {
 	private TestEnum enumProperty;
 
 	private List<Integer> ints = new ArrayList<>();
+
+	private List<Appender<ILoggingEvent>> appenders = new ArrayList<>();
 
 	public int getIntProperty() {
 		return intProperty;
@@ -107,6 +111,14 @@ public class TestBean {
 
 	public List<Integer> getInts() {
 		return ints;
+	}
+
+	public void addAppender(Appender<ILoggingEvent> appender) {
+		appenders.add(appender);
+	}
+
+	public List<Appender<ILoggingEvent>> getAppenders() {
+		return appenders;
 	}
 
 }

--- a/src/test/resources/asyncAppender.conf
+++ b/src/test/resources/asyncAppender.conf
@@ -1,0 +1,43 @@
+logback-root = test.logback
+
+test.logback = ${logback} {
+  appenders {
+    rolling = {
+      class = "ch.qos.logback.core.rolling.RollingFileAppender"
+      encoder {
+        class = "ch.qos.logback.classic.encoder.PatternLayoutEncoder"
+        charset = "UTF-8"
+        pattern = "%date %level %logger %thread %msg%n"
+      }
+
+      file = "logs/test.log"
+
+      rolling-policy = {
+        class = "ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy"
+
+        file-name-pattern = "logs/test%d{yyyy-MM-dd}.%i.log"
+
+        max-file-size = "5MB"
+
+        max-history = 30
+      }
+    }
+
+    async = {
+      class = "ch.qos.logback.classic.AsyncAppender"
+
+      discarding-threshold = 0
+
+      queue-size = 100
+
+      max-flush-time = 1000
+
+      appenders = [ rolling ]
+    }
+  }
+
+  root {
+    level = INFO
+    appenders = [ rolling, async ]
+  }
+}

--- a/src/test/resources/bean.conf
+++ b/src/test/resources/bean.conf
@@ -26,4 +26,6 @@
 
 	ints = [1, 2, 3, 4, 5]
 
+	appenders = [test-appender-1, test-appender-2]
+
 }


### PR DESCRIPTION
Currently this library does not support configuring `AsyncAppender`, because it requires you to add another appender reference during configuration using `addAppender` method.

This pull request adds `ConfigAppendersCache` that is used to lazily load appenders and allow appenders to reference others while being configured.

Note: the cache is very naive in implementation and will not catch looped references or self-references.