### PR TITLE
Lower log level of "no external file" to INFO.

### DIFF
--- a/src/main/java/org/gnieh/logback/config/ConfigConfigurator.java
+++ b/src/main/java/org/gnieh/logback/config/ConfigConfigurator.java
@@ -342,7 +342,7 @@ public class ConfigConfigurator extends ContextAwareBase implements Configurator
             iterator.forEachRemaining(u -> ConfigurationWatchListUtil.addToWatchList(loggerContext, u));
             return true;
         }
-        addWarn("No configuration files to watch, so no file scanning is possible");
+        addInfo("No configuration files to watch, so no file scanning is possible");
         return false;
     }
 


### PR DESCRIPTION
Thanks so much for this library! We've been using it and it's been working great.
One annoyance, though, is the logging every time our app starts:
```
11:34:07,190 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.xml]
11:34:07,191 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.groovy]
11:34:07,191 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.xml]
11:34:07,216 |-INFO in ch.qos.logback.classic.AsyncAppender[async] - Attaching appender named [console] to AsyncAppender.
11:34:07,216 |-INFO in ch.qos.logback.classic.AsyncAppender[async] - Setting discardingThreshold to 51
11:34:07,222 |-WARN in org.gnieh.logback.config.ConfigConfigurator@16f5ed9f - No configuration files to watch, so no file scanning is possible
```
If anything is logged above `INFO`, that triggers logback to log everything.
We don't have any plans to take advantage of that feature (we don't even use external .conf files - we're using Docker deploys mostly currently - so to change the log level, we just restart the service passing in a new env var to set the log level.)
Is there any way to turn off that logging? Or lowering that to `INFO` would do the trick.