### PR TITLE
Support logback context properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ The general configuration format is as follows:
 ```scala
 logback {
   scan-period = 30 seconds
+  
+  properties {
+    property1 = "value"
+  }
 
   appenders {
     appender-name {

--- a/src/main/java/org/gnieh/logback/config/ConfigConfigurator.java
+++ b/src/main/java/org/gnieh/logback/config/ConfigConfigurator.java
@@ -86,6 +86,17 @@ public class ConfigConfigurator extends ContextAwareBase implements Configurator
         // load the configuration per config loading rules
         final Config logbackConfig = config.getConfig(logbackConfigRoot);
 
+        if (logbackConfig.hasPath("properties")) {
+            if (logbackConfig.getValue("properties") instanceof ConfigObject) {
+                final ConfigObject propertyConfigs = (ConfigObject) logbackConfig.getValue("properties");
+                for (Entry<String, ConfigValue> entry : propertyConfigs.toConfig().entrySet()) {
+                    loggerContext.putProperty(entry.getKey(), entry.getValue().unwrapped().toString());
+                }
+            } else {
+                addWarn("Invalid properties configuration. Ignoring it.");
+            }
+        }
+
         final Config appenderConfigs = logbackConfig.getConfig("appenders");
         final ConfigAppendersCache appendersCache = new ConfigAppendersCache();
         appendersCache.setLoader(name -> configureAppender(loggerContext, name, appenderConfigs.getConfig("\"" + name + "\""), beanCache, appendersCache));

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,9 +1,10 @@
 logback-root = logback
 
 logback {
+  properties {}
 
   loggers {}
 
-  appenders = {}
+  appenders {}
 
 }

--- a/src/test/resources/rollingFileAppender.conf
+++ b/src/test/resources/rollingFileAppender.conf
@@ -1,6 +1,9 @@
 logback-root = test.logback
 
 test.logback = ${logback} {
+  properties {
+    fname = test
+  }
   appenders {
     rolling = {
       class = "ch.qos.logback.core.rolling.RollingFileAppender"
@@ -10,12 +13,12 @@ test.logback = ${logback} {
         pattern = "%date %level %logger %thread %msg%n"
       }
 
-      file = "logs/test.log"
+      file = "logs/${fname}.log"
 
       rolling-policy = {
         class = "ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy"
 
-        file-name-pattern = "logs/test%d{yyyy-MM-dd}.%i.log"
+        file-name-pattern = "logs/${fname}%d{yyyy-MM-dd}.%i.log"
 
         max-file-size = "5MB"
 


### PR DESCRIPTION
Hi,

I have a scenario where some configuration (log pattern in my case) is coming from a shared properties file. But each app needs to provide its own app name which is referenced in the pattern.

This PR adds support for configuring properties in the logger context, as one can do with a logback.xml.